### PR TITLE
Usage of TriggerLayerWeapon on AsianHowitzerCannon

### DIFF
--- a/mods/cameo/rules/world.yaml
+++ b/mods/cameo/rules/world.yaml
@@ -892,6 +892,9 @@ World:
 		Brightest: 80
 		FadeoutDelay: 300
 		Name: anthraxpurple
+	WeaponTriggerCells@Inferno:
+		Name: InfernoLayer
+		#ShowDebugOverlay: true
 	SubterraneanActorLayer:
 	JumpjetActorLayer:
 		HeightOffset: 1c256

--- a/mods/cameo/sequences/tiberiansun.yaml
+++ b/mods/cameo/sequences/tiberiansun.yaml
@@ -2830,15 +2830,17 @@ tspulsball:
 		ZOffset: 1023
 		Offset: 0, 0, 24
 
-# tscloud1:
-# 	idle:
-# 		Length: *
-# 		ZOffset: 256
-# 		Offset: 0, 0, 24
-# 	die: tscloud1d
-# 		Length: *
-# 		ZOffset: 256
-# 		Offset: 0, 0, 24
+tscloud1:
+ 	idle:
+		Filename: tscloud1.shp
+ 		Length: *
+ 		ZOffset: 256
+ 		Offset: 0, 0, 24
+ 	die: 
+		Filename: tscloud1d.shp
+ 		Length: *
+ 		ZOffset: 256
+ 		Offset: 0, 0, 24
 
 # tscloud2:
 # 	Inherits: tscloud1

--- a/mods/cameo/weapons/redalert2mod.yaml
+++ b/mods/cameo/weapons/redalert2mod.yaml
@@ -385,9 +385,7 @@ AsianQuasarBoatAA:
 		MinimumLaunchSpeed: 256
 
 AsianHowitzerCannon:
-	Inherits: ^RA2Grenade
-	Inherits: ^HeavyBomb
-	Inherits: ^RA2MediumCannon
+	Inherits: ^Artillery
 	ReloadDelay: 200
 	Report: aa_bgart.wav
 	Range: 20000
@@ -406,6 +404,43 @@ AsianHowitzerCannon:
 		ContrailStartWidth: 100
 		ContrailEndWidth: 20
 		TrailInterval: 1
+		Inaccuracy: 0c256
+	Warhead@1Dam: SpreadDamage
+		Falloff: 100, 55, 20, 5
+		Versus:
+			None: 60
+	Warhead@Cloud: SpawnSmokeParticle
+		Count: 1
+		Duration: 70
+		Speed: 0
+		TurnRate: 10
+		Image: tscloud1
+		Sequences: idle
+		EndSequences: die
+		Palette: shield60
+	Warhead@1Fire: TriggerLayerWeapon
+		LayerName: InfernoLayer
+		TriggerWeapon: AsianSmallOilBomb
+		TriggerSetLevel: 0
+		Level: 0
+		ImpactActors: false
+		ValidTargets: Ground, Water, Air, GroundActor, WaterActor, AirborneActor
+		AirThreshold: 8c0
+		TriggerAtLevelMin: 320
+	Warhead@2Fire: TriggerLayerWeapon
+		LayerName: InfernoLayer
+		AllowSetLevelWhenTrigger: false
+		TriggerAtLevelMin: 50
+		TriggerWeapon: AsianHowitzerSplash
+		ImpactActors: false
+		ValidTargets: Ground, Water, Air, GroundActor, WaterActor, AirborneActor
+		AirThreshold: 8c0
+
+AsianHowitzerSplash:
+	Inherits: ^RA2Grenade
+	Inherits: ^HeavyBomb
+	Inherits: ^RA2MediumCannon
+	Projectile: InstantExplode
 	Warhead@Grenade: SpreadDamage
 		Damage: 20000
 	Warhead@GrenadeFriendlyFire: SpreadDamage


### PR DESCRIPTION
![asia-art](https://github.com/user-attachments/assets/671a026d-2699-4045-bf53-8f484779e306)
Because General factions are locked, I use general-inferno-weapon logic on AsianHowitzerCannon.

You can use it as an example of general-inferno-weapon logic weapon for General and ShockWave in the future.